### PR TITLE
Add --noinput to migrate

### DIFF
--- a/cookbooks/pycon-2014/recipes/app.rb
+++ b/cookbooks/pycon-2014/recipes/app.rb
@@ -11,7 +11,7 @@ application "staging-pycon.python.org" do
   repository "git://github.com/caktus/pycon.git"
   revision "staging"
   packages ["libpq-dev", "git-core"]
-  migration_command "/srv/staging-pycon.python.org/shared/env/bin/python manage.py syncdb --migrate"
+  migration_command "/srv/staging-pycon.python.org/shared/env/bin/python manage.py syncdb --migrate --noinput"
   migrate true
 
   before_symlink do


### PR DESCRIPTION
I haven't been able to see the output of the failed migrate, but it's possible it's pausing looking for input - adding --noinput will cause it to just fail and print errors when it might otherwise prompt.
