### PR TITLE
Keep more settings in Pycon source control.

### DIFF
--- a/cookbooks/pycon-2014/recipes/app.rb
+++ b/cookbooks/pycon-2014/recipes/app.rb
@@ -59,7 +59,7 @@ application "staging-pycon.python.org" do
 
   gunicorn do
     app_module :django
-    environment :SECRET_KEY => secrets["secret_key"], :GRAYLOG_HOST => secrets["graylog_host"], :IS_PRODUCTION => is_production, :DB_NAME => db["database"], :DB_HOST => db["hostname"], :DB_USER => db["user"], :DB_PASSWORD => db["password"]
+    environment :SECRET_KEY => secrets["secret_key"], :GRAYLOG_HOST => secrets["graylog_host"], :IS_PRODUCTION => is_production, :DB_NAME => db["database"], :DB_HOST => db["hostname"], :DB_PORT => "", :DB_USER => db["user"], :DB_PASSWORD => db["password"], :EMAIL_HOST => "mail.python.org", :MEDIA_ROOT => "/srv/staging-pycon.python.org/shared/media/"
   end
 
   nginx_load_balancer do


### PR DESCRIPTION
READY TO MERGE if this looks okay.

The goal is to just override in chef's local_settings file the things that we really only know at deploy time, and keep everything else in settings files in the Pycon source where they're easier to manage.

This would go along with changes in the Pycon source, to default to loading local_settings.py as the top-level settings file, and add the other settings files refered to here, so obviously we couldn't deploy this except in coordination with those changes.

I'm not thrilled with the way local_settings.py.erb assumes the way logging is set up in the settings files it imports, but can't think of another way to keep graylog_host secret and still use it in the logging configuration. We might be better off just keeping the whole logging configuration here; thoughts?
