### PR TITLE
Selectively GZIP

### DIFF
--- a/cookbooks/psf-pypi/metadata.rb
+++ b/cookbooks/psf-pypi/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs and configures PyPI"
-version           "0.0.8"
+version           "0.0.9"
 
 depends           "pgbouncer"
 depends           "rsyslog"

--- a/cookbooks/psf-pypi/templates/default/nginx_pypi.conf.erb
+++ b/cookbooks/psf-pypi/templates/default/nginx_pypi.conf.erb
@@ -62,6 +62,10 @@ server {
     <% if @hsts_seconds %>
     add_header Strict-Transport-Security "max-age=<%= @hsts_seconds %>";
     <% end %>
+
+    gzip on;
+    gzip_comp_level 9;
+    gzip_vary on;
   }
 
   # allow big uploads


### PR DESCRIPTION
So GZIP compression was disabled on PyPI in order to prevent BREACH from affecting us. However there's no sensitive information on the simple index pages or the static url pages so we should be fine turning gzip back on here.
