### PR TITLE
Add cron to run mgmt command that updates Tutorial registrants from CTE

### DIFF
--- a/cookbooks/pycon-2014/recipes/app.rb
+++ b/cookbooks/pycon-2014/recipes/app.rb
@@ -109,6 +109,12 @@ cron "staging-pycon account expunge" do
   command "cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py expunge_deleted"
 end
 
+cron "staging-pycon update tutorial registrants" do
+  hour "0"
+  minute "0"
+  command "cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py update_tutorial_registrants"
+end
+
 firewall 'ufw' do
   action :enable
 end


### PR DESCRIPTION
Configures a nightly cron to call [update_tutorial_registrants](https://github.com/PyCon/pycon/blob/develop/pycon/management/commands/update_tutorial_registrants.py) management command.
