### PR TITLE
New deployment requirements for preview.python.org

### DIFF
--- a/cookbooks/pydotorg-redesign/recipes/staging.rb
+++ b/cookbooks/pydotorg-redesign/recipes/staging.rb
@@ -73,6 +73,10 @@ dpkg_package "yui-compressor" do
     action :install
 end
 
+package "subversion" do
+    action :install
+end
+
 # pip really doesn't like being run without a good env encoding, so fix that.
 ENV['LANG'] = "en_US.UTF-8"
 
@@ -145,6 +149,7 @@ application "redesign.python.org" do
         application_server_role "redesign-staging"
         server_name [node['fqdn'], 'preview.python.org']
         static_files "/static" => 'static-root'
+        static_files "/images" => 'static-root/images'
         application_port 8080
     end
 end

--- a/roles/redesign-staging.rb
+++ b/roles/redesign-staging.rb
@@ -1,6 +1,6 @@
 name "redesign-staging"
 description "Staging server for web redesign project"
-# Owner: Jacob Kaplan-Moss <jacob@jacobian.org>
+# Owners: Jacob Kaplan-Moss <jacob@jacobian.org>, Frank Wiles <frank@revsys.com>
 run_list [
     "recipe[pydotorg-redesign::staging]"
 ]


### PR DESCRIPTION
- Added /images/ -> static-root/images/ to nginx
- Install Subversion package for content importing
