### PR TITLE
Fixing preview.python.org static files mistake

### DIFF
--- a/cookbooks/pydotorg-redesign/recipes/staging.rb
+++ b/cookbooks/pydotorg-redesign/recipes/staging.rb
@@ -148,8 +148,8 @@ application "redesign.python.org" do
     nginx_load_balancer do
         application_server_role "redesign-staging"
         server_name [node['fqdn'], 'preview.python.org']
-        static_files "/static" => 'static-root'
-        static_files "/images" => 'static-root/images'
+        static_files "/static" => 'static-root',
+                     "/images" => 'static-root/images'
         application_port 8080
     end
 end


### PR DESCRIPTION
Made a mistake and believe this fixes it to set nginx to have two static_file locations. Is there a better way to test this than "doing it live"? I'm not sure how to push these to preview except via these pull requests. 
