### PR TITLE
source the env vars before attempting to run management commands

### DIFF
--- a/cookbooks/pycon-2014/recipes/app.rb
+++ b/cookbooks/pycon-2014/recipes/app.rb
@@ -106,13 +106,13 @@ end
 cron_d "staging-pycon-account-expunge" do
   hour "0"
   minute "0"
-  command "cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py expunge_deleted"
+  command "source /srv/staging-pycon.python.org/shared/.env && cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py expunge_deleted"
 end
 
 cron_d "staging-pycon-update-tutorial-registrants" do
   hour "0"
   minute "20"
-  command "cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py update_tutorial_registrants"
+  command "source /srv/staging-pycon.python.org/shared/.env && cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py update_tutorial_registrants"
 end
 
 firewall 'ufw' do


### PR DESCRIPTION
Spoke with @ewdurbin regarding our management commands which were never fully configured to run with the environment variable based setup.  This should resolve the issue.
