### PR TITLE
use nginx return in favor of rewrite.

### DIFF
--- a/cookbooks/psf-pypi/metadata.rb
+++ b/cookbooks/psf-pypi/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs and configures PyPI"
-version           "0.0.22"
+version           "0.0.23"
 
 depends           "pgbouncer"
 depends           "rsyslog"

--- a/cookbooks/psf-pypi/templates/default/nginx_pypi.conf.erb
+++ b/cookbooks/psf-pypi/templates/default/nginx_pypi.conf.erb
@@ -76,6 +76,6 @@ server {
 server {
   listen 80;
   server_name <%= @domains.last(@domains.length - 1).join(" ") %>;
-  rewrite ^ $scheme://<%= @domains.first %>$request_uri permanent;
+  return 301 $scheme://<%= @domains.first %>$request_uri;
 }
 <% end %>

--- a/cookbooks/psf-pypi/templates/default/nginx_redirect.conf.erb
+++ b/cookbooks/psf-pypi/templates/default/nginx_redirect.conf.erb
@@ -3,5 +3,5 @@
 
 server {
   server_name <%= @existing_domain %>;
-  rewrite ^ $scheme://<%= @new_domain %>$request_uri permanent;
+  return 301 $scheme://<%= @new_domain %>$request_uri;
 }


### PR DESCRIPTION
URL is now rewritten without duplicating the request parameters. this was causing old links to cheeseshop to be forwarded to pypi with double actions and whatnot.

I think the rewrite could have been fixed with a `^/$` but i'm more confident with the return 301.
