### PR TITLE
Disable backups of OSUOSL PyPI Infrastructure.

### DIFF
--- a/cookbooks/psf-pypi/metadata.rb
+++ b/cookbooks/psf-pypi/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs and configures PyPI"
-version           "0.0.23"
+version           "0.0.24"
 
 depends           "pgbouncer"
 depends           "rsyslog"

--- a/cookbooks/psf-pypi/recipes/default.rb
+++ b/cookbooks/psf-pypi/recipes/default.rb
@@ -1,3 +1,6 @@
+
+resources('rsnapshot_backup[/]').action(:nothing)
+
 sysctl_param 'kernel.panic' do
   value 10
 end


### PR DESCRIPTION
We're running low on space in the OSUOSL backup server.

Now that PyPI is hosted elsewhere, and this infr is way out of date, these backups were rather useless (and large).
