### PR TITLE
set Host header to legacy.python.org to address python/pythondotorg#346

### DIFF
--- a/cookbooks/pydotorg-redesign/templates/default/nginx.conf.erb
+++ b/cookbooks/pydotorg-redesign/templates/default/nginx.conf.erb
@@ -48,7 +48,7 @@ server {
   location ~ ^/~(.*)$ {
     resolver 8.8.8.8;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header Host $host;
+    proxy_set_header Host legacy.python.org;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_pass http://legacy.python.org/~$1;
   }


### PR DESCRIPTION
When I was setting up the CDN for downloads, I removed dinsdale's virtualhost configuration for www.python.org. Thus, we have to change the host header to get the proxying to work.
