### PR TITLE
add missing django message includes

### DIFF
--- a/cookbooks/pypy-codespeed/templates/default/settings.py.erb
+++ b/cookbooks/pypy-codespeed/templates/default/settings.py.erb
@@ -76,6 +76,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
 )
 
 if DEBUG:
@@ -118,6 +119,7 @@ INSTALLED_APPS = (
     #'django.contrib.sites',
     'django.contrib.admin',
     'django.contrib.staticfiles',
+    'django.contrib.messages',
     'codespeed',
     'south',
     'gunicorn'


### PR DESCRIPTION
Apparently at some stage django was updated, but the settings.py for pypy's codespeed was not. This causes problems when trying to administer the site.
