### PR TITLE
Adds virtualenv activation to cron jobs for pycon

### DIFF
--- a/cookbooks/psf-pycon/recipes/app.rb
+++ b/cookbooks/psf-pycon/recipes/app.rb
@@ -112,13 +112,13 @@ end
 cron_d "staging-pycon-account-expunge" do
   hour "0"
   minute "0"
-  command "bash -c 'source /srv/staging-pycon.python.org/shared/.env && cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py expunge_deleted'"
+  command "bash -c 'source /srv/staging-pycon.python.org/shared/.env && source /srv/staging-pycon.python.org/shared/env/bin/activate && cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py expunge_deleted'"
 end
 
 cron_d "staging-pycon-update-tutorial-registrants" do
   hour "0"
   minute "20"
-  command "bash -c 'source /srv/staging-pycon.python.org/shared/.env && cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py update_tutorial_registrants'"
+  command "bash -c 'source /srv/staging-pycon.python.org/shared/.env && source /srv/staging-pycon.python.org/shared/env/bin/activate && cd /srv/staging-pycon.python.org/current && /srv/staging-pycon.python.org/shared/env/bin/python manage.py update_tutorial_registrants'"
 end
 
 firewall 'ufw' do


### PR DESCRIPTION
The cron jobs for the Pycon site don't activate the virutalenvironment. This makes the expunge_deleted management command unavailable because it isn't on the PYTHON_PATH