### PR TITLE
Restore sudo access on speed-python

### DIFF
--- a/data_bags/users/zware.json
+++ b/data_bags/users/zware.json
@@ -1,7 +1,7 @@
 {
   "id": "zware",
   "comment": "Zach Ware",
-  "sudo": ["buildmaster"],
+  "sudo": ["buildmaster", "python-speed"],
   "ssh_keys": [
     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC5vqLruv6gzJgZ7zaKJnaWzzWAW7azAtetqMPVN+67cGMcQtnRmG2ih6UOXc1fA0fuZudKBgqlRw3Yg2UcT8ehP505PoHVuq+j0uZ4ogzQ8BJbZIaMEfbPXdzwUfqU3Ju3sur0XQYu0HHexKUU6ZZjjwl5LOmw9dTtY0cb7N7emePy//c7IaDuNsWg+4zaTDUwEhyWLVw6Ev4e0b1ufDxTvHqRXMVCfq0IYMsRXcg8+88GGF8kIS4QMbX/GcsFfOLHj35aJbAk6dqcCZWXWX/bRL937KYl9zENOkvlRbodEZqufDBsa+7Dm29LeV9JPfKJU3+5qM/LkfYPBiw1rH0L zach@screamer"
   ]


### PR DESCRIPTION
Apparently I had been added manually; upgrading the box to Ubuntu 16.04 seems to have awakened Chef.  See also #160.